### PR TITLE
Add distributed client-server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ To check for updates and new features, you can also revisit the [Releases](https
 
 ![Username Checker](https://example.com/screenshot.png)
 
+## Distributed Mode
+
+You can now distribute username checks across multiple servers. Run the `server` binary on each machine and set the `SERVERS` environment variable on the client with a comma-separated list of server URLs (e.g. `http://ip1:8080,http://ip2:8080`).
+The client will automatically detect available servers, split the target list and goroutines equally, and collect the results.
+
 ## Technologies Used
 
 - **Go**: The primary programming language for building this tool.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -1,0 +1,119 @@
+package checker
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ytax/snapchat-username-checker/modules/requestparser"
+	"google.golang.org/protobuf/proto"
+)
+
+// CheckUsername returns true if the provided username is available.
+func CheckUsername(username string) (bool, error) {
+	req := &requestparser.SuggestUsernameRequest{
+		Username:      &requestparser.SuggestUsernameRequest_NameWrapper{Name: username},
+		Locale:        "",
+		SomethingFlag: 0,
+		DeviceId:      "c798e85f-4511-66b0-889a-ef303fa6bfab",
+		SessionId:     "6687bd20-731d-387c-e3b9-d47c5a90f410",
+	}
+
+	body, err := proto.Marshal(req)
+	if err != nil {
+		return false, err
+	}
+
+	payload := append([]byte{0}, uint32ToBytes(uint32(len(body)))...)
+	payload = append(payload, body...)
+
+	headers := map[string]string{
+		"Content-Type":            "application/grpc",
+		"TE":                      "trailers",
+		"Grpc-Accept-Encoding":    "identity, deflate, gzip",
+		"Grpc-Timeout":            "3S",
+		"User-Agent":              "Snapchat/13.21.0.43 (moto g play (2021); Android 11#e00ca2#30; gzip) V/MUSHROOM grpc-c++/1.48.0 grpc-c/26.0.0 (android; cronet_http)",
+		"Allow-Recycled-Username": "true",
+		"X-Request-Id":            "63adac91-301f-46d3-a576-44c28d302153",
+	}
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	url := "https://aws.api.snapchat.com/snapchat.activation.api.SuggestUsernameService/SuggestUsername"
+	reqHTTP, err := http.NewRequest("POST", url, bytes.NewReader(payload))
+	if err != nil {
+		return false, err
+	}
+
+	for k, v := range headers {
+		reqHTTP.Header.Set(k, v)
+	}
+
+	resp, err := client.Do(reqHTTP)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	bodyResp, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, err
+	}
+	if len(bodyResp) <= 5 {
+		return false, nil
+	}
+	bodyResp = bodyResp[5:]
+
+	var response requestparser.SuggestUsernameResponse
+	if err := proto.Unmarshal(bodyResp, &response); err != nil {
+		return false, err
+	}
+
+	suggestions := response.GetSuggestions()
+	return len(suggestions) > 0 && suggestions[0] == username, nil
+}
+
+// CheckUsernames checks a list of usernames using a pool of workers.
+func CheckUsernames(usernames []string, workers int) (available []string, unavailable []string) {
+	if workers <= 0 {
+		workers = 1
+	}
+
+	sem := make(chan struct{}, workers)
+	results := make(chan struct {
+		name  string
+		avail bool
+	})
+
+	for _, u := range usernames {
+		u := u
+		sem <- struct{}{}
+		go func() {
+			avail, _ := CheckUsername(u)
+			results <- struct {
+				name  string
+				avail bool
+			}{u, avail}
+			<-sem
+		}()
+	}
+
+	for range usernames {
+		r := <-results
+		if r.avail {
+			available = append(available, r.name)
+		} else {
+			unavailable = append(unavailable, r.name)
+		}
+	}
+	return
+}
+
+func uint32ToBytes(n uint32) []byte {
+	return []byte{
+		byte(n >> 24),
+		byte(n >> 16),
+		byte(n >> 8),
+		byte(n),
+	}
+}

--- a/client/main.go
+++ b/client/main.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+)
+
+type checkRequest struct {
+	Usernames  []string `json:"usernames"`
+	Goroutines int      `json:"goroutines"`
+}
+
+type checkResponse struct {
+	Available   []string `json:"available"`
+	Unavailable []string `json:"unavailable"`
+}
+
+func readTargets(filename string) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var targets []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		t := strings.TrimSpace(scanner.Text())
+		if t != "" {
+			targets = append(targets, t)
+		}
+	}
+	return targets, scanner.Err()
+}
+
+func main() {
+	var targetsFile string
+	var goroutines int
+	flag.StringVar(&targetsFile, "targets", "targets.txt", "file with usernames")
+	flag.IntVar(&goroutines, "goroutines", 100, "total goroutines")
+	flag.Parse()
+
+	targets, err := readTargets(targetsFile)
+	if err != nil {
+		fmt.Println("failed to read targets:", err)
+		return
+	}
+
+	srvEnv := os.Getenv("SERVERS")
+	if srvEnv == "" {
+		fmt.Println("SERVERS environment variable not set")
+		return
+	}
+	srvList := strings.Split(srvEnv, ",")
+	var servers []string
+	for _, s := range srvList {
+		s = strings.TrimSpace(s)
+		resp, err := http.Get(s + "/ping")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			servers = append(servers, s)
+		}
+	}
+	if len(servers) == 0 {
+		fmt.Println("no servers available")
+		return
+	}
+
+	fmt.Printf("Detected %d servers\n", len(servers))
+
+	perServer := len(targets) / len(servers)
+	gorPerServer := goroutines / len(servers)
+	if gorPerServer == 0 {
+		gorPerServer = 1
+	}
+	idx := 0
+	var allAvailable []string
+
+	for i, srv := range servers {
+		start := idx
+		end := idx + perServer
+		if i == len(servers)-1 {
+			end = len(targets)
+		}
+		part := targets[start:end]
+		idx = end
+
+		reqBody := checkRequest{Usernames: part, Goroutines: gorPerServer}
+		data, _ := json.Marshal(reqBody)
+		resp, err := http.Post(srv+"/check", "application/json", bytes.NewReader(data))
+		if err != nil {
+			fmt.Printf("server %s error: %v\n", srv, err)
+			continue
+		}
+		var res checkResponse
+		if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+			fmt.Printf("server %s invalid response\n", srv)
+			continue
+		}
+		allAvailable = append(allAvailable, res.Available...)
+	}
+
+	fmt.Printf("Available usernames (%d):\n", len(allAvailable))
+	for _, u := range allAvailable {
+		fmt.Println(u)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/ytax/snapchat-username-checker/checker"
+)
+
+type checkRequest struct {
+	Usernames  []string `json:"usernames"`
+	Goroutines int      `json:"goroutines"`
+}
+
+type checkResponse struct {
+	Available   []string `json:"available"`
+	Unavailable []string `json:"unavailable"`
+}
+
+func handlePing(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("pong"))
+}
+
+func handleCheck(w http.ResponseWriter, r *http.Request) {
+	var req checkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if req.Goroutines <= 0 {
+		req.Goroutines = 1
+	}
+	avail, unavail := checker.CheckUsernames(req.Usernames, req.Goroutines)
+	resp := checkResponse{Available: avail, Unavailable: unavail}
+	json.NewEncoder(w).Encode(resp)
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ping", handlePing)
+	mux.HandleFunc("/check", handleCheck)
+	log.Println("Server listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}


### PR DESCRIPTION
## Summary
- add `checker` package with reusable checking logic
- add `server` binary exposing `/ping` and `/check` endpoints
- add `client` binary that splits work across available servers
- document the new distributed mode in README

## Testing
- `go build -o /tmp/client ./client`
- `go build -o /tmp/server ./server`


------
https://chatgpt.com/codex/tasks/task_e_685f3e179f7483248335a40f1364da05